### PR TITLE
Add UNPROTECTED_ARTIFACTS=1 so artifacts are uploaded publicly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   global:
     - PLUGIN_NAME=PlatformsReport
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
+    - UNPROTECTED_ARTIFACTS=1
     # this variable controls the version of Piwik your tests will run against. increment it when
     # making your plugin compatible with the new version of Piwik.
     - PIWIK_TEST_TARGET=2.15.0


### PR DESCRIPTION
When plugins are open source, artifacts can be uploaded publicly. as a result, developers don't need to specify login/password to the `tests:sync-ui-screenshots`

Refs https://github.com/piwik/piwik/issues/7761